### PR TITLE
Add extra column to save job OS name

### DIFF
--- a/database/sql/create_table-server_status.sql
+++ b/database/sql/create_table-server_status.sql
@@ -1,5 +1,6 @@
 CREATE TABLE IF NOT EXISTS server_status(
     job_name TEXT PRIMARY KEY NOT NULL,
     server_status TEXT,
-    release TEXT
+    release TEXT,
+    os_name TEXT
 );


### PR DESCRIPTION
To update the buildfarmer.db, I added manually the missing field and then ran the private fetching script.