### PR TITLE
Remove % operators to match exactly error names

### DIFF
--- a/database/scripts/calculate_flakiness_jobs.sql
+++ b/database/scripts/calculate_flakiness_jobs.sql
@@ -37,7 +37,7 @@ recent_failures AS (
         AND build_status.job_name = test_failures.job_name
 	AND build_status.status IN ("SUCCESS", "UNSTABLE")
         AND build_status.build_datetime >= DATE('now', '-@param2@')
-        AND test_failures.error_name LIKE '%@param1@%'
+        AND test_failures.error_name LIKE '@param1@'
     GROUP BY build_status.job_name
 )
 SELECT build_status.job_name,

--- a/database/scripts/calculate_flakiness_nodes.sql
+++ b/database/scripts/calculate_flakiness_nodes.sql
@@ -35,7 +35,7 @@ recent_failures AS (
 		build_status.build_number = test_failures.build_number
 		AND build_status.job_name = test_failures.job_name
 	WHERE build_status.build_datetime >= DATE('now', '-30 days')
-		AND test_failures.error_name LIKE '%@param1@%'
+		AND test_failures.error_name LIKE '@param1@'
 		AND build_status.node_name LIKE '%@param3@%'
 	GROUP BY build_status.node_name, build_status.job_name
 ) 

--- a/database/scripts/errors_get_first_time.sql
+++ b/database/scripts/errors_get_first_time.sql
@@ -9,6 +9,6 @@ FROM test_failures
         test_failures.build_number = build_status.build_number
         AND test_failures.job_name = build_status.job_name
     )
-WHERE test_failures.error_name LIKE "%@param1@%"
+WHERE test_failures.error_name LIKE "@param1@"
 ORDER BY build_status.build_datetime ASC
 LIMIT 25

--- a/database/scripts/errors_get_last_ones.sql
+++ b/database/scripts/errors_get_last_ones.sql
@@ -9,6 +9,6 @@ FROM test_failures
         test_failures.build_number = build_status.build_number
         AND test_failures.job_name = build_status.job_name
     )
-WHERE test_failures.error_name LIKE "%@param1@%"
+WHERE test_failures.error_name LIKE "@param1@"
 ORDER BY build_status.build_datetime DESC
 LIMIT 25;


### PR DESCRIPTION
As the title says. 

It was also mentioned in [this comment](https://github.com/osrf/buildfarm-tools/issues/32#issuecomment-1988829460)