### PR TITLE
Warn if a test regression doesn't show an output from sql_run script

### DIFF
--- a/database/scripts/check_buildfarm.rb
+++ b/database/scripts/check_buildfarm.rb
@@ -40,7 +40,12 @@ def get_issues_list(jobs_to_filter = [])
   issues_map = Hash.new
   test_regressions_today.each do |tr|
     tr_flakiness = %x{./sql_run.sh calculate_flakiness_jobs.sql "#{tr['error_name']}" "15 days"}
-    tr_flakiness_output = parse_sql_output(tr_flakiness).uniq { |item| item["job_name"] }
+    tr_flakiness_raw_out = parse_sql_output(tr_flakiness)
+    if tr_flakiness_raw_out.nil?
+      puts "WARNING: Error parsing flakiness output for '#{tr['error_name']}' in #{tr['job_name']}##{tr['build_number']}"
+      next
+    end
+    tr_flakiness_output = tr_flakiness_raw_out.uniq { |item| item["job_name"] }
     tr_flakiness_output.map { |item|
       item['error_name'] = tr['error_name']
       item['github_issues'] = parse_known_issues(tr['error_name'])


### PR DESCRIPTION
## Description

This is a patch, so Daily Workflow action can run in peace.

The error is caused because some test regressions have backslash character in their name (check https://github.com/osrf/buildfarm-tools/issues/37#issuecomment-2032478460 for exact example).

When this happens, sql_run script can't run a clean query, so the output is empty, and check_buildfarm fails to parse the result.

(Reference build: https://github.com/osrf/buildfarm-tools/actions/runs/8522086112)

## Fix

The change just checks if the output is empty, in that case, it yells which test regression is causing the problem
