### PR TITLE
Fix backslash bug: Escape backslashes in `sql_run` before running query

### DIFF
--- a/database/scripts/sql_run.sh
+++ b/database/scripts/sql_run.sh
@@ -18,7 +18,8 @@ else
     param_n=1
     while echo "$query" | grep -qo "param$param_n" 
     do
-        query=$(echo "$query" | sed "s|@param$param_n@|${args[$param_n]}|g")
+        arg_param=$(echo "${args[$param_n]}" | sed -e 's|\\|\\\\|g') # escape backslashes
+        query=$(echo "$query" | sed "s|@param$param_n@|$arg_param|g")
         param_n=$((param_n+1))
     done
 


### PR DESCRIPTION
As the title says

Example query: `./sql_run.sh errors_get_last_ones.sql "rclpy.flake8.A006 (.\rclpy\node.py:989:20)"`

Output:
```
error_name|package_name|job_name|build_number|build_datetime|node_name
rclpy.flake8.A006 (.\rclpy\node.py:989:20)|rclpy|nightly_win_rel|3003|2024-04-02 04:00:01.925000|windows-container-9a11ba30
rclpy.flake8.A006 (.\rclpy\node.py:989:20)|rclpy|nightly_win_deb|3051|2024-04-02 04:00:01.919000|windows-container-8b1b2241
```