### PR TITLE
Add Jazzy distribution to ROS Dashboard

### DIFF
--- a/ROS2.md
+++ b/ROS2.md
@@ -1,5 +1,4 @@
 # ROS 2 Build Status
-
 ## Nightly Platform CI
 
 Builds [ros2.repos](https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos) from source.
@@ -18,17 +17,16 @@ Builds [ros2.repos](https://raw.githubusercontent.com/ros2/ros2/master/ros2.repo
 
 From http://build.ros2.org . All Linux jobs, alternating days for released distributions: https://github.com/ros2/ros_buildfarm_config/pull/112
 
-|  | Humble | Iron | Rolling |
-|---|---|---|---|
-| Nightly Release | [![Build Status][Hci-release-badge]][Hci-release] | [![Build Status][Ici-release-badge]][Ici-release] | [![Build Status][Rci-release-badge]][Rci-release] |
-| Nightly Debug | [![Build Status][Hci-debug-badge]][Hci-debug] | [![Build Status][Ici-debug-badge]][Ici-debug] | [![Build Status][Rci-debug-badge]][Rci-debug] |
-| Nightly Performance | [![Build Status][Hci-performance-badge]][Hci-performance] | [![Build Status][Ici-performance-badge]][Ici-performance] | [![Build Status][Rci-performance-badge]][Rci-performance] |
-| Nightly Connext | [![Build Status][Hci-connext-badge]][Hci-connext] | [![Build Status][Ici-connext-badge]][Ici-connext] | [![Build Status][Rci-connext-badge]][Rci-connext] |
-| Nightly Cyclone | [![Build Status][Hci-cyclone-badge]][Hci-cyclone] | [![Build Status][Ici-cyclone-badge]][Ici-cyclone] | [![Build Status][Rci-cyclone-badge]][Rci-cyclone] |
-| Nightly FastRTPS | [![Build Status][Hci-fastrtps-badge]][Hci-fastrtps] | [![Build Status][Ici-fastrtps-badge]][Ici-fastrtps] | [![Build Status][Rci-fastrtps-badge]][Rci-fastrtps] |
-| Nightly FastRTPS Dynamic | [![Build Status][Hci-fastrtps-dynamic-badge]][Hci-fastrtps-dynamic] | [![Build Status][Ici-fastrtps-dynamic-badge]][Ici-fastrtps-dynamic] | [![Build Status][Rci-fastrtps-dynamic-badge]][Rci-fastrtps-dynamic] |
-| Benchmarks | [![Build Status][Hci-benchmark-badge]][Hci-benchmark] | [![Build Status][Ici-benchmark-badge]][Ici-benchmark] | [![Build Status][Rci-benchmark-badge]][Rci-benchmark] |
-| Coverage | [![Build Status][Hci-coverage-badge]][Hci-coverage] | [![Build Status][Ici-coverage-badge]][Ici-coverage] | [![Build Status][Rci-coverage-badge]][Rci-coverage] |
+|  | Humble | Iron | Jazzy | Rolling |
+|---|---|---|---|---|
+| Nightly Release | [![Build Status][Hci-release-badge]][Hci-release] | [![Build Status][Ici-release-badge]][Ici-release] |  [![Build Status][Jci-release-badge]][Jci-release] | [![Build Status][Rci-release-badge]][Rci-release] |
+| Nightly Debug | [![Build Status][Hci-debug-badge]][Hci-debug] | [![Build Status][Ici-debug-badge]][Ici-debug] | [![Build Status][Jci-debug-badge]][Jci-debug] | [![Build Status][Rci-debug-badge]][Rci-debug] |
+| Nightly Performance | [![Build Status][Hci-performance-badge]][Hci-performance] | [![Build Status][Ici-performance-badge]][Ici-performance] | [![Build Status][Jci-performance-badge]][Jci-performance] | [![Build Status][Rci-performance-badge]][Rci-performance] |
+| Nightly Cyclone | [![Build Status][Hci-cyclone-badge]][Hci-cyclone] | [![Build Status][Ici-cyclone-badge]][Ici-cyclone] | [![Build Status][Jci-cyclone-badge]][Jci-cyclone] | [![Build Status][Rci-cyclone-badge]][Rci-cyclone] |
+| Nightly FastRTPS | [![Build Status][Hci-fastrtps-badge]][Hci-fastrtps] | [![Build Status][Ici-fastrtps-badge]][Ici-fastrtps] | [![Build Status][Jci-fastrtps-badge]][Jci-fastrtps] | [![Build Status][Rci-fastrtps-badge]][Rci-fastrtps] |
+| Nightly FastRTPS Dynamic | [![Build Status][Hci-fastrtps-dynamic-badge]][Hci-fastrtps-dynamic] | [![Build Status][Ici-fastrtps-dynamic-badge]][Ici-fastrtps-dynamic] | [![Build Status][Jci-fastrtps-dynamic-badge]][Jci-fastrtps-dynamic] | [![Build Status][Rci-fastrtps-dynamic-badge]][Rci-fastrtps-dynamic] |
+| Benchmarks | [![Build Status][Hci-benchmark-badge]][Hci-benchmark] | [![Build Status][Ici-benchmark-badge]][Ici-benchmark] | [![Build Status][Jci-benchmark-badge]][Jci-benchmark] | [![Build Status][Rci-benchmark-badge]][Rci-benchmark] |
+| Coverage | [![Build Status][Hci-coverage-badge]][Hci-coverage] | [![Build Status][Ici-coverage-badge]][Ici-coverage] | [![Build Status][Jci-coverage-badge]][Jci-coverage] | [![Build Status][Rci-coverage-badge]][Rci-coverage] |
 
 ## Upload OSUOSL Repositories
 ### ROS 1
@@ -126,6 +124,25 @@ From http://build.ros2.org . All Linux jobs, alternating days for released distr
 [Ici-benchmark]: http://build.ros2.org/view/Ici/job/Ici__benchmark_ubuntu_jammy_amd64/
 [Ici-coverage-badge]: https://ci.ros2.org/buildStatus/icon?job=nightly_linux_iron_coverage
 [Ici-coverage]: https://ci.ros2.org/job/nightly_linux_iron_coverage/
+
+[Jci-release-badge]: http://build.ros2.org/buildStatus/icon?job=Jci__nightly-release_ubuntu_noble_amd64
+[Jci-release]: http://build.ros2.org/view/Jci/job/Jci__nightly-release_ubuntu_noble_amd64/
+[Jci-debug-badge]: http://build.ros2.org/buildStatus/icon?job=Jci__nightly-debug_ubuntu_noble_amd64
+[Jci-debug]: http://build.ros2.org/view/Jci/job/Jci__nightly-debug_ubuntu_noble_amd64/
+[Jci-performance-badge]: http://build.ros2.org/buildStatus/icon?job=Jci__nightly-performance_ubuntu_noble_amd64
+[Jci-performance]: http://build.ros2.org/view/Jci/job/Jci__nightly-performance_ubuntu_noble_amd64/
+[Jci-connext-badge]: http://build.ros2.org/buildStatus/icon?job=Jci__nightly-connext_ubuntu_noble_amd64
+[Jci-connext]: http://build.ros2.org/view/Jci/job/Jci__nightly-connext_ubuntu_noble_amd64/
+[Jci-cyclone-badge]: http://build.ros2.org/buildStatus/icon?job=Jci__nightly-cyclonedds_ubuntu_noble_amd64
+[Jci-cyclone]: http://build.ros2.org/view/Jci/job/Jci__nightly-cyclonedds_ubuntu_noble_amd64/
+[Jci-fastrtps-badge]: http://build.ros2.org/buildStatus/icon?job=Jci__nightly-fastrtps_ubuntu_noble_amd64
+[Jci-fastrtps]: http://build.ros2.org/view/Jci/job/Jci__nightly-fastrtps_ubuntu_noble_amd64/
+[Jci-fastrtps-dynamic-badge]: http://build.ros2.org/buildStatus/icon?job=Jci__nightly-fastrtps-dynamic_ubuntu_noble_amd64
+[Jci-fastrtps-dynamic]:  http://build.ros2.org/view/Jci/job/Jci__nightly-fastrtps-dynamic_ubuntu_noble_amd64/
+[Jci-benchmark-badge]: http://build.ros2.org/buildStatus/icon?job=Jci__benchmark_ubuntu_noble_amd64
+[Jci-benchmark]: http://build.ros2.org/view/Jci/job/Jci__benchmark_ubuntu_noble_amd64/
+[Jci-coverage-badge]: https://ci.ros2.org/buildStatus/icon?job=nightly_linux_iron_coverage
+[Jci-coverage]: https://ci.ros2.org/job/nightly_linux_iron_coverage/
 
 [Rci-release-badge]: http://build.ros2.org/buildStatus/icon?job=Rci__nightly-release_ubuntu_noble_amd64
 [Rci-release]: http://build.ros2.org/view/Rci/job/Rci__nightly-release_ubuntu_noble_amd64/

--- a/ROS2.md
+++ b/ROS2.md
@@ -141,8 +141,8 @@ From http://build.ros2.org . All Linux jobs, alternating days for released distr
 [Jci-fastrtps-dynamic]:  http://build.ros2.org/view/Jci/job/Jci__nightly-fastrtps-dynamic_ubuntu_noble_amd64/
 [Jci-benchmark-badge]: http://build.ros2.org/buildStatus/icon?job=Jci__benchmark_ubuntu_noble_amd64
 [Jci-benchmark]: http://build.ros2.org/view/Jci/job/Jci__benchmark_ubuntu_noble_amd64/
-[Jci-coverage-badge]: https://ci.ros2.org/buildStatus/icon?job=nightly_linux_iron_coverage
-[Jci-coverage]: https://ci.ros2.org/job/nightly_linux_iron_coverage/
+[Jci-coverage-badge]: https://ci.ros2.org/buildStatus/icon?job=nightly_linux_jazzy_coverage
+[Jci-coverage]: https://ci.ros2.org/job/nightly_linux_jazzy_coverage/
 
 [Rci-release-badge]: http://build.ros2.org/buildStatus/icon?job=Rci__nightly-release_ubuntu_noble_amd64
 [Rci-release]: http://build.ros2.org/view/Rci/job/Rci__nightly-release_ubuntu_noble_amd64/


### PR DESCRIPTION
As the title says:
* :scroll: [ROS2 Dashboard](https://github.com/osrf/buildfarm-tools/blob/Crola1702/add-jazzy/ROS2.md)
