### PR TITLE
Generate report script (urgent section)

### DIFF
--- a/database/scripts/generate_report.rb
+++ b/database/scripts/generate_report.rb
@@ -28,18 +28,19 @@ def generate_report(report_name, exclude_set)
     report = {
         'urgent' => {
             'build_regressions' => urgent_build_regressions = BuildfarmToolsLib::build_regressions_today(filter_known: true),
-            'test_regressions_consistent' => urgent_consistent_test_regressions = BuildfarmToolsLib::test_regressions_today(filter_known: true, only_consistent: true),
+            'test_regressions_consecutive' => urgent_consistent_test_regressions = BuildfarmToolsLib::test_regressions_today(filter_known: true, only_consistent: true),
             'test_regressions_flaky' => urgent_flaky_test_regressions = BuildfarmToolsLib::flaky_test_regressions(filter_known: true),
        },
        'maintenance' => {
             'jobs_failing' => [],
             'gh_issues_reported' => [],
-            'disabled_tests' => [],
+            'tests_disabled' => [],
        },
        'pending' => {
            'build_regressions_known' => [],
            'test_regressions_all' => [],
            'test_regressions_known' => [],
+           'build_regressions_known' => [],
        }
     }
 

--- a/database/scripts/generate_report.rb
+++ b/database/scripts/generate_report.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+
+require_relative 'lib/buildfarm_tools'
+require 'date'
+require 'json'
+require 'optparse'
+require 'ostruct'
+
+options = {}
+optparser = OptionParser.new do |o|
+    o.on "-e", "--exclude EXCLUDE_JOBS", "A list of string separated by spaces that represent the regex on a job name that you want to exclude" do |exclude|
+        options[:exclude] = Set.new(exclude.split(" "))
+    end
+    o.on "-o" "--output OUTPUT", "Name of output report" do |out|
+        options[:report_name] = out
+    end
+    o.on("-h", "--help", "Prints this help") do
+        puts o
+        exit
+    end
+end
+
+optparser.parse!(ARGV)
+options[:exclude] = Set.new() if options[:exclude].nil?
+options[:report_name] = "buildfarm-report_#{DateTime.now.strftime("%Y-%m-%d_%H-%M")}.json" if options[:report_name].nil?
+
+def generate_report(report_name, exclude_set)
+    report = {
+        'urgent' => {
+            'build_regressions' => urgent_build_regressions = BuildfarmToolsLib::build_regressions_today(filter_known: true),
+            'test_regressions_consistent' => urgent_consistent_test_regressions = BuildfarmToolsLib::test_regressions_today(filter_known: true, only_consistent: true),
+            'test_regressions_flaky' => urgent_flaky_test_regressions = BuildfarmToolsLib::flaky_test_regressions(filter_known: true),
+       },
+       'maintenance' => {
+            'jobs_failing' => [],
+            'gh_issues_reported' => [],
+            'disabled_tests' => [],
+       },
+       'pending' => {
+           'build_regressions_known' => [],
+           'test_regressions_all' => [],
+           'test_regressions_known' => [],
+       }
+    }
+
+
+    File.open(report_name, 'w') do |f|
+        f.write(report.to_json)
+    end
+end
+
+generate_report(options[:report_name], options[:exclude])


### PR DESCRIPTION
# Description

As discussed in https://github.com/osrf/buildfarm-tools/issues/57#issuecomment-2176897854, the new report must contain an urgent section.

The `generate_report.rb` uses the library from #60 to generate a JSON file containing information from all sections of the defined report. As an example:

```
{
  "urgent": {
    "build_regressions": [ ... ],
    "test_regressions_consecutive": [ ... ],
    "test_regressions_flaky": [ ... ]
  },
  "maintenance": {
    "jobs_failing": [ <empty> ],
    "gh_issues_reported": [ <empty> ],
    "tests_disabled": [ <empty> ]
  },
  "pending": {
    "build_regressions_known": [ <empty> ],
    "test_regressions_all": [ <empty> ],
    "test_regressions_known": [ <empty> ],
    "build_regressions_known": [ <empty> ]
  }
}
```

A complete example generated report: [buildfarm-report_2024-06-25_12-10.json](https://github.com/user-attachments/files/15973822/buildfarm-report_2024-06-25_12-10.json)



