### PR TITLE
Report formatter base

### DIFF
--- a/database/scripts/format_report.rb
+++ b/database/scripts/format_report.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require_relative 'lib/report_formatter'
+require 'json'
+
+report_name = ARGV.shift
+
+report = JSON.load_file(report_name)
+
+report['urgent']['build_regressions'] = ReportFormatter::build_regressions(report['urgent']['build_regressions'])
+
+# Sample output:
+puts report['urgent']['build_regressions']

--- a/database/scripts/format_report.rb
+++ b/database/scripts/format_report.rb
@@ -9,9 +9,7 @@ report = JSON.load_file(report_name)
 
 report['urgent']['build_regressions'] = ReportFormatter::build_regressions(report['urgent']['build_regressions'])
 report['urgent']['test_regressions_consecutive'] = ReportFormatter::test_regressions_consecutive(report['urgent']['test_regressions_consecutive'])
-
-# These are not implemented yet!!!
-report['urgent']['test_regressions_flaky'] = []
+report['urgent']['test_regressions_flaky'] = ReportFormatter::test_regressions_flaky(report['urgent']['test_regressions_flaky'])
 
 # Sample output:
 # puts report['urgent']['build_regressions']

--- a/database/scripts/format_report.rb
+++ b/database/scripts/format_report.rb
@@ -9,5 +9,10 @@ report = JSON.load_file(report_name)
 
 report['urgent']['build_regressions'] = ReportFormatter::build_regressions(report['urgent']['build_regressions'])
 
+# These are not implemented yet!!!
+report['urgent']['test_regressions_consecutive'] = []
+report['urgent']['test_regressions_flaky'] = []
+
 # Sample output:
-puts report['urgent']['build_regressions']
+# puts report['urgent']['build_regressions']
+puts ReportFormatter::format_report report

--- a/database/scripts/format_report.rb
+++ b/database/scripts/format_report.rb
@@ -8,9 +8,9 @@ report_name = ARGV.shift
 report = JSON.load_file(report_name)
 
 report['urgent']['build_regressions'] = ReportFormatter::build_regressions(report['urgent']['build_regressions'])
+report['urgent']['test_regressions_consecutive'] = ReportFormatter::test_regressions_consecutive(report['urgent']['test_regressions_consecutive'])
 
 # These are not implemented yet!!!
-report['urgent']['test_regressions_consecutive'] = []
 report['urgent']['test_regressions_flaky'] = []
 
 # Sample output:

--- a/database/scripts/generate_report.rb
+++ b/database/scripts/generate_report.rb
@@ -29,7 +29,7 @@ def generate_report(report_name, exclude_set)
         'urgent' => {
             'build_regressions' => urgent_build_regressions = BuildfarmToolsLib::build_regressions_today(filter_known: true),
             'test_regressions_consecutive' => urgent_consistent_test_regressions = BuildfarmToolsLib::test_regressions_today(filter_known: true, only_consistent: true, group_issues: true),
-            'test_regressions_flaky' => urgent_flaky_test_regressions = BuildfarmToolsLib::flaky_test_regressions(filter_known: true),
+            'test_regressions_flaky' => urgent_flaky_test_regressions = BuildfarmToolsLib::flaky_test_regressions(filter_known: true, group_issues: true),
        },
        'maintenance' => {
             'jobs_failing' => [],

--- a/database/scripts/generate_report.rb
+++ b/database/scripts/generate_report.rb
@@ -28,7 +28,7 @@ def generate_report(report_name, exclude_set)
     report = {
         'urgent' => {
             'build_regressions' => urgent_build_regressions = BuildfarmToolsLib::build_regressions_today(filter_known: true),
-            'test_regressions_consecutive' => urgent_consistent_test_regressions = BuildfarmToolsLib::test_regressions_today(filter_known: true, only_consistent: true),
+            'test_regressions_consecutive' => urgent_consistent_test_regressions = BuildfarmToolsLib::test_regressions_today(filter_known: true, only_consistent: true, group_issues: true),
             'test_regressions_flaky' => urgent_flaky_test_regressions = BuildfarmToolsLib::flaky_test_regressions(filter_known: true),
        },
        'maintenance' => {
@@ -50,4 +50,4 @@ def generate_report(report_name, exclude_set)
 end
 
 generate_report(options[:report_name], options[:exclude])
-puts report_name
+puts options[:report_name]

--- a/database/scripts/generate_report.rb
+++ b/database/scripts/generate_report.rb
@@ -40,7 +40,6 @@ def generate_report(report_name, exclude_set)
            'build_regressions_known' => [],
            'test_regressions_all' => [],
            'test_regressions_known' => [],
-           'build_regressions_known' => [],
        }
     }
 
@@ -51,3 +50,4 @@ def generate_report(report_name, exclude_set)
 end
 
 generate_report(options[:report_name], options[:exclude])
+puts report_name

--- a/database/scripts/lib/buildfarm_tools.rb
+++ b/database/scripts/lib/buildfarm_tools.rb
@@ -34,7 +34,7 @@ module BuildfarmToolsLib
     run_command('./sql_run.sh error_appearances_in_job.sql', args: [test_name, job_name])
   end
 
-  def self.test_regressions_today(filter_known: false, only_consistent: false)
+  def self.test_regressions_today(filter_known: false, only_consistent: false, group_issues: false)
     # Keys: job_name, build_number, error_name, build_datetime, node_name
     out = run_command('./sql_run.sh errors_check_last_build.sql')
     if filter_known
@@ -44,6 +44,10 @@ module BuildfarmToolsLib
     if only_consistent
       out.filter! { |tr| tr['age'].to_i >= CONSECUTIVE_THRESHOLD || tr['age'].to_i == WARNING_AGE_CONSTANT }
       out.sort_by! { |tr| -tr['age'].to_i }
+    end
+    if group_issues
+      # Group by (job_name, age)
+      out = out.group_by { |o| [o['job_name'], o['age']] }.to_a.map { |e| e[1] }
     end
     out
   end

--- a/database/scripts/lib/buildfarm_tools.rb
+++ b/database/scripts/lib/buildfarm_tools.rb
@@ -45,6 +45,9 @@ module BuildfarmToolsLib
       out.filter! { |tr| tr['age'].to_i >= CONSECUTIVE_THRESHOLD || tr['age'].to_i == WARNING_AGE_CONSTANT }
       out.sort_by! { |tr| -tr['age'].to_i }
     end
+    out.each do |e|
+      e['reports'] = test_regression_reported_issues e['error_name']
+    end
     if group_issues
       # Group by (job_name, age)
       out = out.group_by { |o| [o['job_name'], o['age']] }.to_a.map { |e| e[1] }

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -54,9 +54,10 @@ module ReportFormatter
   def self.test_regressions_consecutive(tr_array)
     return "" if tr_array.empty?
     table = "| Reference build | Age | Failure DateTime | Errors | Reports |\n| -- | -- | -- | -- | -- |\n"
+    warnings_table = table
     tr_array.each do |tr_issue|
       reference_build = format_reference_build(tr_issue[0])
-      age = tr_issue.first['age']
+      age = tr_issue.first['age'].to_i
       failure_datetime = tr_issue.first['build_datetime']
       errors = ""
       reports = []
@@ -76,14 +77,21 @@ module ReportFormatter
       # If output is too long, wrap it in a <details>
       errors = "<details><summary>#{tr_issue.size} errors</summary>#{errors}</details>" if tr_issue.size >= 10
 
-      table += "| #{reference_build} | #{age} | #{failure_datetime} | #{errors} | #{reports_str} |\n"
+      if age == -1
+        warnings_table += "| #{reference_build} | #{age} | #{failure_datetime} | #{errors} | #{reports_str} |\n"
+      else
+        table += "| #{reference_build} | #{age} | #{failure_datetime} | #{errors} | #{reports_str} |\n"
+      end
     end
-    table
+    out = "### Test regressions\n#{table}\n"
+    out += "### Warnings\n#{warnings_table}\n" if warnings_table.count("\n") > 2
+    out
   end
 
   def self.test_regressions_flaky(tr_array)
     return "" if tr_array.empty?
     table = "| Reference builds | Errors | Flaky report | Reports |\n| -- | -- | -- | -- |\n"
+    warnings_table = table
     tr_array.each do |tr|
       jobs = []
       errors = []
@@ -109,9 +117,15 @@ module ReportFormatter
         reports_str = "No reports found!"
       end
       
-      table += "|#{jobs_str}|#{errors_str}|<details>#{format_flakiness(tr.first['flakiness'])}</details>|#{reports_str}|\n"
+      if tr.first['age'].to_i == -1
+        warnings_table += "|#{jobs_str}|#{errors_str}|<details>#{format_flakiness(tr.first['flakiness'])}</details>|#{reports_str}|\n"
+      else
+        table += "|#{jobs_str}|#{errors_str}|<details>#{format_flakiness(tr.first['flakiness'])}</details>|#{reports_str}|\n"
+      end
     end
-    table
+    out = "### Test regressions\n#{table}\n"
+    out += "### Warnings\n#{warnings_table}\n" if warnings_table.count("\n") > 2
+    out
   end
   
 

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -29,6 +29,7 @@ module ReportFormatter
   end
 
   def self.build_regressions(br_array)
+    return "" if br_array.empty?
     table = "| Reference Build | Failure DateTime | Failure Reason |\n| -- | -- | -- |\n"
     br_array.each do |br_hash|
       reference_build = "[#{br_hash['job_name']}##{br_hash['build_number']}](#{get_build_url(br_hash['job_name'], br_hash['build_number'])})"
@@ -42,15 +43,18 @@ module ReportFormatter
     output_report = ""
 
     report_hash.each_pair do |category, subcategory_hash|
-      output_report += "<details><summary><h1>#{category}</h1></summary>\n"
+      output_report += "<h1>#{category.gsub('_', ' ').capitalize}</h1>"
       subcategory_hash.each_pair do |subcategory, subcategory_report| # Assume that we're traversing a hash of hashes
-        output_report += "<details><summary><h2>#{subcategory}</h2></summary>\n"
-        
-        # Subcategory report is plain markdown
-        output_report += !subcategory_report.empty? ? "\n#{subcategory_report}\n" : "Emtpy!!"
-        output_report += "</details>\n"
+        next if subcategory_report.empty?
+
+        subcategory_report_title = "<h2>#{subcategory.gsub('_', ' ').capitalize}</h2>"
+        if category = 'urgent'
+          subcategory_report_str = "#{subcategory_report_title}\n#{subcategory_report}"
+        else
+          subcategory_report_str = "<details><summary>#{subcategory_report_title}</summary>\n#{subcategory_report}<details>"
+        end
+        output_report += subcategory_report_str
       end
-      output_report += "</details>\n"
     end
     output_report
   end

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module ReportFormatter
+  JOB_URL_PATTERN = {
+    /^gz|^sdformat|^ros_gz/ => 'https://build.osrfoundation.org/job/',
+    /^[A-Z]ci/ => 'https://build.ros2.org/job/',
+    /^nightly_/ => 'https://ci.ros2.org/job/',
+  }
+
+  def self.get_build_url(job_name, build_number)
+    base_url = ""
+
+    JOB_URL_PATTERN.each_pair do |pattern, url|
+      if pattern.match? job_name
+        base_url = url
+        break
+      end
+    end
+
+    "#{base_url}#{job_name}/#{build_number}"
+  end
+
+  def self.format_datetime(datetime)
+    date, time = datetime.split
+    hour, minute, _ = time.split(':')
+    "#{date} #{hour}:#{minute}"
+  end
+
+  def self.build_regressions(br_array)
+    table = "| Reference Build | Failure DateTime | Failure Reason |\n| -- | -- | -- |\n"
+    br_array.each do |br_hash|
+      reference_build = "[#{br_hash['job_name']}##{br_hash['build_number']}](#{get_build_url(br_hash['job_name'], br_hash['build_number'])})"
+      table += "| #{reference_build} | #{format_datetime(br_hash['build_datetime'])} | #{br_hash['failure_reason']} |\n"
+    end
+    table
+  end
+
+end

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -42,9 +42,9 @@ module ReportFormatter
     output_report = ""
 
     report_hash.each_pair do |category, subcategory_hash|
-      output_report += "<details><summary><h1>#{category}</h1></summary>"
+      output_report += "<details><summary><h1>#{category}</h1></summary>\n"
       subcategory_hash.each_pair do |subcategory, subcategory_report| # Assume that we're traversing a hash of hashes
-        output_report += "<details><summary><h2>#{subcategory}</h2></summary>"
+        output_report += "<details><summary><h2>#{subcategory}</h2></summary>\n"
         
         # Subcategory report is plain markdown
         output_report += !subcategory_report.empty? ? "\n#{subcategory_report}\n" : "Emtpy!!"

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -111,7 +111,7 @@ module ReportFormatter
       errors_str = "<details><summary>#{errors.size} items</summary>\n#{errors_str}</details>" if errors.size >= 10
 
       if reports.size > 0
-        reports_str = reports.uniq.map { |e| "<li>#{e['github_issue']} (#{e['status'].capitalize})</li>"}.join
+        reports_str = reports.uniq.map { |e| "<li>`#{e['github_issue']}` (#{e['status'].capitalize})</li>"}.join
         reports_str = "<ul>#{reports_str}</ul>"
       else
         reports_str = "No reports found!"

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -37,4 +37,21 @@ module ReportFormatter
     table
   end
 
+  def self.format_report(report_hash)
+    # Use <details> and <summary> tags to prevent long reports
+    output_report = ""
+
+    report_hash.each_pair do |category, subcategory_hash|
+      output_report += "<details><summary><h1>#{category}</h1></summary>"
+      subcategory_hash.each_pair do |subcategory, subcategory_report| # Assume that we're traversing a hash of hashes
+        output_report += "<details><summary><h2>#{subcategory}</h2></summary>"
+        
+        # Subcategory report is plain markdown
+        output_report += !subcategory_report.empty? ? "\n#{subcategory_report}\n" : "Emtpy!!"
+        output_report += "</details>\n"
+      end
+      output_report += "</details>\n"
+    end
+    output_report
+  end
 end

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -6,7 +6,7 @@ module ReportFormatter
   JOB_URL_PATTERN = {
     /^gz|^sdformat|^ros_gz/ => 'https://build.osrfoundation.org/job/',
     /^[A-Z]ci/ => 'https://build.ros2.org/job/',
-    /^nightly_/ => 'https://ci.ros2.org/job/',
+    /^nightly_|^packaging_/ => 'https://ci.ros2.org/job/',
   }
 
   def self.get_build_url(job_name, build_number)

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -9,7 +9,9 @@ module ReportFormatter
     /^nightly_|^packaging_/ => 'https://ci.ros2.org/job/',
   }
 
-  def self.get_build_url(job_name, build_number)
+  def self.format_reference_build(issue_hash)
+    job_name = issue_hash['job_name']
+    build_number = issue_hash['build_number']
     base_url = ""
 
     JOB_URL_PATTERN.each_pair do |pattern, url|
@@ -19,7 +21,7 @@ module ReportFormatter
       end
     end
 
-    "#{base_url}#{job_name}/#{build_number}"
+    "[#{job_name}##{build_number}](#{base_url}#{job_name}/#{build_number})"
   end
 
   def self.format_datetime(datetime)
@@ -32,8 +34,29 @@ module ReportFormatter
     return "" if br_array.empty?
     table = "| Reference Build | Failure DateTime | Failure Reason |\n| -- | -- | -- |\n"
     br_array.each do |br_hash|
-      reference_build = "[#{br_hash['job_name']}##{br_hash['build_number']}](#{get_build_url(br_hash['job_name'], br_hash['build_number'])})"
+      reference_build = format_reference_build(br_hash)
       table += "| #{reference_build} | #{format_datetime(br_hash['build_datetime'])} | #{br_hash['failure_reason']} |\n"
+    end
+    table
+  end
+
+  def self.test_regressions_consecutive(tr_array)
+    return "" if tr_array.empty?
+    table = "| Reference build | Age | Failure DateTime | Errors |\n| -- | -- | -- | -- |\n"
+    tr_array.each do |tr_issue|
+      reference_build = format_reference_build(tr_issue[0])
+      age = tr_issue[0]['age']
+      failure_datetime = tr_issue[0]['build_datetime']
+      errors = ""
+      tr_issue.each do |e|
+        errors += "<li>#{e['error_name']}</li>"
+      end
+      errors = "<ul>#{errors}</ul>"
+
+      # If output is too long, wrap it in a <details>
+      errors = "<details><summary>#{tr_issue.size} errors</summary>#{errors}</details>" if tr_issue.size >= 10
+
+      table += "| #{reference_build} | #{age} | #{failure_datetime} | #{errors} |\n"
     end
     table
   end
@@ -43,16 +66,13 @@ module ReportFormatter
     output_report = ""
 
     report_hash.each_pair do |category, subcategory_hash|
-      output_report += "<h1>#{category.gsub('_', ' ').capitalize}</h1>"
+      output_report += "<h1>#{category.gsub('_', ' ').capitalize}</h1>\n"
       subcategory_hash.each_pair do |subcategory, subcategory_report| # Assume that we're traversing a hash of hashes
         next if subcategory_report.empty?
 
-        subcategory_report_title = "<h2>#{subcategory.gsub('_', ' ').capitalize}</h2>"
-        if category = 'urgent'
-          subcategory_report_str = "#{subcategory_report_title}\n#{subcategory_report}"
-        else
-          subcategory_report_str = "<details><summary>#{subcategory_report_title}</summary>\n#{subcategory_report}<details>"
-        end
+        subcategory_report_title = "<h2>#{subcategory.gsub('_', ' ').capitalize}</h2>\n"
+        subcategory_report_str = "#{subcategory_report_title}\n#{subcategory_report}\n"
+        subcategory_report_str = "<details><summary>#{subcategory_report_title}</summary>\n#{subcategory_report}<details>\n" unless category == 'urgent'
         output_report += subcategory_report_str
       end
     end

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -67,7 +67,7 @@ module ReportFormatter
       errors = "<ul>#{errors}</ul>"
 
       if reports.size > 0
-        reports_str = reports.uniq.map { |e| "<li>#{e['github_issue']} (#{e['status'].capitalize})</li>"}.join
+        reports_str = reports.uniq.map { |e| "<li>`#{e['github_issue']}` (#{e['status'].capitalize})</li>"}.join
         reports_str = "<ul>#{reports_str}</ul>"
       else
         reports_str = "No reports found!"
@@ -93,7 +93,7 @@ module ReportFormatter
         errors << e['error_name']
         reports += e['reports']
       end
-      jobs.uniq.map! { |e| "<li>#{e}</li>" }
+      jobs = jobs.uniq.map { |e| "<li>#{e}</li>" }
       errors.map! { |e| "<li>#{e}</li>" }
 
       jobs_str = "<ul>#{jobs.join}</ul>"


### PR DESCRIPTION
# Description

Part of #57 

#62 adds `generate_report.rb` script, which generates a json file with daily issues (e.g., [buildfarm-report_2024-06-25_12-10.json](https://github.com/user-attachments/files/15973822/buildfarm-report_2024-06-25_12-10.json)). The idea is to parse this report into a Markdown format to be posted daily in [buildfarmer log report](https://github.com/osrf/buildfarm-tools/issues?q=is%3Aissue+is%3Aopen+label%3Abuildfarmer-log). 

Current output is pretty simple:

<details>
<summary>
Example output:
</summary>

<details><summary><h1>urgent</h1></summary><details><summary><h2>build_regressions</h2></summary>

| Reference Build | Failure DateTime | Failure Reason |
| -- | -- | -- |
| [gz_sim-ci-ign-gazebo6-homebrew-amd64#59](https://build.osrfoundation.org/job/gz_sim-ci-ign-gazebo6-homebrew-amd64/59) | 2024-06-30 18:06 | Unknown Reason |
| [nightly_win_deb#3141](https://ci.ros2.org/job/nightly_win_deb/3141) | 2024-07-01 04:00 | Packages rclcpp  Failed |

</details>
<details><summary><h2>test_regressions_consecutive</h2></summary>Emtpy!!</details>
<details><summary><h2>test_regressions_flaky</h2></summary>Emtpy!!</details>
</details>
<details><summary><h1>maintenance</h1></summary><details><summary><h2>jobs_failing</h2></summary>Emtpy!!</details>
<details><summary><h2>gh_issues_reported</h2></summary>Emtpy!!</details>
<details><summary><h2>tests_disabled</h2></summary>Emtpy!!</details>
</details>
<details><summary><h1>pending</h1></summary><details><summary><h2>test_regressions_all</h2></summary>Emtpy!!</details>
<details><summary><h2>test_regressions_known</h2></summary>Emtpy!!</details>
<details><summary><h2>build_regressions_known</h2></summary>Emtpy!!</details>
</details>

</details>
