### PR TITLE
Daily Report: Known test regressions report subsection

### DIFF
--- a/database/scripts/format_report.rb
+++ b/database/scripts/format_report.rb
@@ -11,6 +11,7 @@ report['urgent']['build_regressions'] = ReportFormatter::build_regressions(repor
 report['urgent']['test_regressions_consecutive'] = ReportFormatter::test_regressions_consecutive(report['urgent']['test_regressions_consecutive'])
 report['urgent']['test_regressions_flaky'] = ReportFormatter::test_regressions_flaky(report['urgent']['test_regressions_flaky'])
 report['maintenance']['jobs_last_success_date'] = ReportFormatter::jobs_last_success_date(report['maintenance']['jobs_last_success_date'])
+report['pending']['test_regressions_known'] = ReportFormatter::test_regressions_known(report['pending']['test_regressions_known'])
 
 # Sample output:
 # puts report['urgent']['build_regressions']

--- a/database/scripts/generate_report.rb
+++ b/database/scripts/generate_report.rb
@@ -39,7 +39,7 @@ def generate_report(report_name, exclude_set)
        'pending' => {
            'build_regressions_known' => [],
            'test_regressions_all' => [],
-           'test_regressions_known' => [],
+           'test_regressions_known' => pending_test_regressions_known = BuildfarmToolsLib::test_regressions_known,
        }
     }
 

--- a/database/scripts/generate_report.rb
+++ b/database/scripts/generate_report.rb
@@ -28,7 +28,7 @@ def generate_report(report_name, exclude_set)
     report = {
         'urgent' => {
             'build_regressions' => urgent_build_regressions = BuildfarmToolsLib::build_regressions_today(filter_known: true),
-            'test_regressions_consecutive' => urgent_consistent_test_regressions = BuildfarmToolsLib::test_regressions_today(filter_known: true,only_consistent: true, group_issues: true),
+            'test_regressions_consecutive' => urgent_consistent_test_regressions = BuildfarmToolsLib::test_regressions_today(filter_known: true, only_consistent: true, group_issues: true),
             'test_regressions_flaky' => urgent_flaky_test_regressions = BuildfarmToolsLib::flaky_test_regressions(filter_known: true, group_issues: true),
        },
        'maintenance' => {

--- a/database/scripts/generate_report.rb
+++ b/database/scripts/generate_report.rb
@@ -27,9 +27,9 @@ options[:report_name] = "buildfarm-report_#{DateTime.now.strftime("%Y-%m-%d_%H-%
 def generate_report(report_name, exclude_set)
     report = {
         'urgent' => {
-            'build_regressions' => urgent_build_regressions = BuildfarmToolsLib::build_regressions_today(),
-            'test_regressions_consecutive' => urgent_consistent_test_regressions = BuildfarmToolsLib::test_regressions_today(only_consistent: true, group_issues: true),
-            'test_regressions_flaky' => urgent_flaky_test_regressions = BuildfarmToolsLib::flaky_test_regressions(group_issues: true),
+            'build_regressions' => urgent_build_regressions = BuildfarmToolsLib::build_regressions_today(filter_known: true),
+            'test_regressions_consecutive' => urgent_consistent_test_regressions = BuildfarmToolsLib::test_regressions_today(filter_known: true,only_consistent: true, group_issues: true),
+            'test_regressions_flaky' => urgent_flaky_test_regressions = BuildfarmToolsLib::flaky_test_regressions(filter_known: true, group_issues: true),
        },
        'maintenance' => {
             'jobs_last_success_date' => maintenance_jobs_last_success_date = BuildfarmToolsLib::jobs_last_success_date(older_than_days: 7),

--- a/database/scripts/lib/buildfarm_tools.rb
+++ b/database/scripts/lib/buildfarm_tools.rb
@@ -113,6 +113,12 @@ module BuildfarmToolsLib
     out
   end
 
+  def self.test_regressions_known
+    out = known_issues(status: 'open')
+    out = out.group_by { |e| e["github_issue"] }.to_a.map { |e| e[1] }
+    out
+  end
+
   def self.run_command(cmd, args: [], keys: [])
     cmd += " '#{args.shift}'" until args.empty?
     begin

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -151,6 +151,7 @@ module ReportFormatter
   end
 
   def self.test_regressions_known(issue_array)
+    # Create a table for each project: {'ros' => <table>, 'gazebo' => <table>}
     tables = Hash[JOB_PROJECT_PATTERN.values.each_with_object("| Issue | Jobs Name | Errors Name |\n| -- | -- | -- |\n").to_a]
     issue_array.each do |iss_report|
       jobs = iss_report.map { |o| o['job_name'] }.uniq
@@ -161,8 +162,8 @@ module ReportFormatter
       errors_str = "<ul><li>#{errors.join('</li><li>')}</li></ul>"
       errors_str = "<details><summary>#{errors.size} errors</summary>#{errors_str}</details>" if errors.size > 9
       
+      # Add issue report data to it's respective project table
       project = get_job_project(jobs[0])
-      
       tables[project] += "| `#{iss_report[0]['github_issue']}` | #{jobs_str} | #{errors_str} |\n"
     end
     out = ""

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -151,7 +151,7 @@ module ReportFormatter
   end
 
   def self.test_regressions_known(issue_array)
-    tables = Hash[JOB_PROJECT_PATTERN.values.each_with_object("| Issue | Job Name | Error Name |\n| -- | -- | -- |\n").to_a]
+    tables = Hash[JOB_PROJECT_PATTERN.values.each_with_object("| Issue | Jobs Name | Errors Name |\n| -- | -- | -- |\n").to_a]
     issue_array.each do |iss_report|
       jobs = iss_report.map { |o| o['job_name'] }.uniq
       jobs_str = "<ul><li>#{jobs.join('</li><li>')}</li></ul>"

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -137,9 +137,25 @@ module ReportFormatter
     table
   end
 
+  def self.test_regressions_known(issue_array)
+    table = "| Issue | Job Name | Error Name |\n| -- | -- | -- |\n"
+    issue_array.each do |iss_report|
+      jobs = iss_report.map { |o| o['job_name'] }.uniq
+      jobs_str = "<ul><li>#{jobs.join('</li><li>')}</li></ul>"
+      jobs_str = "<details><summary>#{jobs.size} jobs</summary>#{jobs_str}</details>" if jobs.size > 9
+
+      errors = iss_report.map { |o| o['error_name'] }.uniq
+      errors_str = "<ul><li>#{errors.join('</li><li>')}</li></ul>"
+      errors_str = "<details><summary>#{errors.size} errors</summary>#{errors_str}</details>" if errors.size > 9
+
+      table += "| `#{iss_report[0]['github_issue']}` | #{jobs_str} | #{errors_str} |\n"
+    end
+    table
+  end
+
   def self.format_report(report_hash)
     # Use <details> and <summary> tags to prevent long reports
-    details_subcategories = ['test_regressions_flaky', 'jobs_last_success_date']
+    details_subcategories = ['test_regressions_flaky', 'jobs_last_success_date', 'test_regressions_known']
     output_report = ""
 
     report_hash.each_pair do |category, subcategory_hash|


### PR DESCRIPTION
# Description

This PR adds the "Test regressions known" subsection defined in: https://github.com/osrf/buildfarm-tools/issues/57#issuecomment-2176897854

## Changes

* Add new method in `lib/buildfarm_tools.rb` to get open known issues (known issues with an issue that is still open)
* Add new method in `lib/report_formatter.rb` to get the project (i.e., ros, gazebo) from the name of a job.
* Format open known issues by creating a table of `| GH issue | Jobs | Errors |` for ros and gazebo
    * This is a milestone to have the exact open issues for ROS and Gazebo each day, so we can track daily which issues are opened
* Restore `filter_known` flag in `generate_report.rb`, as now the open issues are reported in this section, and open issues create noise in the urgent section

Examples:
* [buildfarm-report_2024-08-05_15-48.json](https://github.com/user-attachments/files/16502785/buildfarm-report_2024-08-05_15-48.json)
* :scroll: [report.md](https://github.com/user-attachments/files/16502787/report.md)
