### PR TITLE
Feat: Track disabled issues

### DIFF
--- a/database/scripts/lib/buildfarm_tools.rb
+++ b/database/scripts/lib/buildfarm_tools.rb
@@ -115,6 +115,7 @@ module BuildfarmToolsLib
 
   def self.test_regressions_known
     out = known_issues(status: 'open')
+    out.concat known_issues(status: 'disabled')
     out = out.group_by { |e| e["github_issue"] }.to_a.map { |e| e[1] }
     out
   end

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -169,9 +169,7 @@ module ReportFormatter
       # Add issue report data to it's respective project table
       project = get_job_project(jobs[0])
       tables[project][iss_report.first['status'].downcase] += "| `#{iss_report[0]['github_issue']}` | #{jobs_str} | #{errors_str} |\n"
-      # puts tables
     end
-    # puts
 
     out = ""
     tables.each_pair do |project, v|

--- a/database/sql/create_table-test_fail_issues.sql
+++ b/database/sql/create_table-test_fail_issues.sql
@@ -6,7 +6,8 @@ CREATE TABLE IF NOT EXISTS test_fail_issues(
     status TEXT DEFAULT "OPEN" CHECK (
         status IN (
             "OPEN",
-            "CLOSED"
+            "CLOSED",
+            "DISABLED"
         )
     ) NOT NULL ON CONFLICT REPLACE DEFAULT "OPEN"
 );


### PR DESCRIPTION
# Description

We're currently tracking disabled tests in https://github.com/orgs/osrf/projects/24. This is good for tracking issues, however, this workflow is not integrated with buildfarm tools and buildfarm database.

This PR adds the disabled status for known issues, so we can list which are the disabled issues by project.

# Changes

* Add `DISABLED` status check in buildfarmer.db `test_fail_issues` table schema 
    * Update disabled tests from https://github.com/orgs/osrf/projects/24/views/1
* Add disabled issues return in `BuildfarmTools::test_regressions_known`
* Show disabled issues by project (separated from open issues)

Examples:
* [buildfarm-report_2024-08-22_06-20.json](https://github.com/user-attachments/files/16710752/buildfarm-report_2024-08-22_06-20.json)
* :scroll: [report.md](https://github.com/user-attachments/files/16710754/report.md)

