### PR TITLE
Report formatter: Get job domain and project from database

### DIFF
--- a/database/scripts/builds_failing_today.sql
+++ b/database/scripts/builds_failing_today.sql
@@ -2,8 +2,11 @@ SELECT bf.job_name,
     bf.build_number,
     bs.build_datetime,
     bf.failure_reason,
-    bf.last_section
+    bf.last_section,
+    server_status.project,
+    server_status.domain
 FROM build_status bs
     INNER JOIN build_failures bf ON bs.build_number = bf.build_number
+    INNER JOIN server_status ON server_status.job_name = bf.job_name
     AND bs.job_name = bf.job_name
 WHERE bs.build_datetime > DATETIME('now', '-1 day')

--- a/database/scripts/calculate_flakiness_jobs.sql
+++ b/database/scripts/calculate_flakiness_jobs.sql
@@ -48,10 +48,13 @@ SELECT build_status.job_name,
     ROUND(
         CAST(recent_failures.failure_count AS FLOAT) / recent_builds.build_count * 100,
         2
-    ) AS failure_percentage
+    ) AS failure_percentage,
+    server_status.project,
+    server_status.domain
 FROM build_status,
     recent_builds,
     recent_failures
+INNER JOIN server_status ON server_status.job_name = build_status.job_name
 WHERE recent_builds.job_name = build_status.job_name
     AND recent_failures.job_name = build_status.job_name
     AND recent_failures.failure_count > 0

--- a/database/scripts/error_appearances_in_job.sql
+++ b/database/scripts/error_appearances_in_job.sql
@@ -2,12 +2,15 @@ SELECT test_failures.error_name,
     test_failures.job_name,
     test_failures.build_number,
     build_status.build_datetime,
-    build_status.node_name
+    build_status.node_name,
+    server_status.project,
+    server_status.domain
 FROM test_failures
     INNER JOIN build_status ON (
         test_failures.build_number = build_status.build_number
         AND test_failures.job_name = build_status.job_name
     )
+    INNER JOIN server_status ON server_status.job_name = test_failures.job_name
 WHERE test_failures.error_name LIKE "@param1@"
     AND test_failures.job_name LIKE "@param2@"
 ORDER BY build_status.build_datetime DESC;

--- a/database/scripts/errors_check_last_build.sql
+++ b/database/scripts/errors_check_last_build.sql
@@ -3,7 +3,9 @@ SELECT tf.job_name,
     tf.error_name,
     bs.build_datetime,
     bs.node_name,
-    tf.age
+    tf.age,
+    server_status.project,
+    server_status.domain
 FROM build_status bs
     INNER JOIN last_time_updated lt ON (
         lt.last_build_number = bs.build_number
@@ -13,5 +15,6 @@ FROM build_status bs
         lt.last_build_number = tf.build_number
         AND lt.job_name = tf.job_name
     )
+    INNER JOIN server_status ON server_status.job_name = tf.job_name
 WHERE bs.build_datetime > DATETIME('now', '-4 days') -- Outdated job threshold
 ORDER BY bs.job_name DESC

--- a/database/scripts/get_known_issues.sql
+++ b/database/scripts/get_known_issues.sql
@@ -1,6 +1,9 @@
 SELECT error_name,
-    job_name,
+    test_fail_issues.job_name,
     github_issue,
-    status
+    status,
+    server_status.project,
+    server_status.domain
 FROM test_fail_issues
+    INNER JOIN server_status ON server_status.job_name = test_fail_issues.job_name
 WHERE status LIKE "%@param1@%";

--- a/database/scripts/is_known_issue.sql
+++ b/database/scripts/is_known_issue.sql
@@ -1,6 +1,9 @@
 SELECT error_name,
-    job_name,
+    test_fail_issues.job_name,
     github_issue,
-    status
+    status,
+    server_status.project,
+    server_status.domain
 FROM test_fail_issues
+    INNER JOIN server_status ON test_fail_issues.job_name = server_status.job_name
 WHERE error_name LIKE "%@param1@%";

--- a/database/scripts/jobs_last_success.sql
+++ b/database/scripts/jobs_last_success.sql
@@ -1,4 +1,7 @@
-SELECT job_name, last_success_time
+SELECT last_success_times.job_name,
+    last_success_times.last_success_time,
+    server_status.project,
+    server_status.domain
 FROM (
     SELECT bs.job_name, MAX(bs.build_datetime) AS last_success_time
     FROM build_status bs
@@ -6,4 +9,5 @@ FROM (
     WHERE bs.status = 'SUCCESS'
     GROUP BY bs.job_name
 ) AS last_success_times
+INNER JOIN server_status ON last_success_times.job_name = server_status.job_name
 ORDER BY last_success_time ASC;

--- a/database/scripts/jobs_never_passed.sql
+++ b/database/scripts/jobs_never_passed.sql
@@ -1,7 +1,9 @@
 SELECT bs.job_name,
-    COUNT(*) as failed_build_count
+    COUNT(*) as failed_build_count,
+    server_status.project,
+    server_status.domain
 FROM build_status bs
-INNER JOIN server_status ss ON bs.job_name = ss.job_name
+INNER JOIN server_status ON server_status.job_name = bs.job_name
 WHERE bs.job_name NOT IN (
     SELECT job_name
     FROM build_status

--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -3,16 +3,8 @@
 require 'json'
 
 module ReportFormatter
-  JOB_URL_PATTERN = {
-    /^gz|^sdformat|^ros_gz/ => 'https://build.osrfoundation.org/job/',
-    /^[A-Z]ci/ => 'https://build.ros2.org/job/',
-    /^nightly_|^packaging_/ => 'https://ci.ros2.org/job/',
-  }
 
-  JOB_PROJECT_PATTERN = {
-    /^gz|^sdformat|^ros_gz/ => 'gazebo',
-    /^[A-Z]ci|^nightly_|^packaging_/ => 'ros',
-  }
+  TRACKED_PROJECTS = %w[ROS GAZEBO]
 
   def self.get_job_project(job_name)
     project_name = ""
@@ -25,16 +17,9 @@ module ReportFormatter
   def self.format_reference_build(issue_hash)
     job_name = issue_hash['job_name']
     build_number = issue_hash['build_number']
-    base_url = ""
+    base_url = issue_hash['domain']
 
-    JOB_URL_PATTERN.each_pair do |pattern, url|
-      if pattern.match? job_name
-        base_url = url
-        break
-      end
-    end
-
-    "[#{job_name}##{build_number}](#{base_url}#{job_name}/#{build_number})"
+    "[#{job_name}##{build_number}](#{base_url}/#{job_name}/#{build_number})"
   end
 
   def self.format_datetime(datetime)
@@ -154,8 +139,7 @@ module ReportFormatter
     # Create a table for each project: {'ros' => {'open' => <table>, 'disabled' => <table>}, 'gazebo' => {'open' => <table>, 'disabled' => <table>}}
     table_template = "| Issue | Jobs Name | Errors Name |\n| -- | -- | -- |\n"
     table_by_status = {'open' => table_template, 'disabled' => table_template}
-    projects = JOB_PROJECT_PATTERN.values.to_a
-    tables = Hash[projects.zip([table_by_status, table_by_status.clone])]
+    tables = Hash[TRACKED_PROJECTS.zip([table_by_status, table_by_status.clone])]
 
     issue_array.each do |iss_report|
       jobs = iss_report.map { |o| o['job_name'] }.uniq
@@ -167,7 +151,7 @@ module ReportFormatter
       errors_str = "<details><summary>#{errors.size} errors</summary>#{errors_str}</details>" if errors.size > 9
       
       # Add issue report data to it's respective project table
-      project = get_job_project(jobs[0])
+      project = iss_report.first['project']
       tables[project][iss_report.first['status'].downcase] += "| `#{iss_report[0]['github_issue']}` | #{jobs_str} | #{errors_str} |\n"
     end
 
@@ -176,7 +160,7 @@ module ReportFormatter
       out += "### #{project.capitalize}\n"
       v.each_pair do |status, table|
         next if table == table_template
-        out += "#### #{status} issues\n"
+        out += "#### #{status.titelize} issues\n"
         out += "#{table}\n"
       end
     end


### PR DESCRIPTION
# Description

This PR updates buildfarm tools scripts to user new project and domain columns from server_status table added in #84 

Closes #68 

## Changes

* Update all sql queries used by `buildfarm_tools.rb` to get project and domain columns from a join with server_status table
* Refactor code to userproject and domain attributes added in the report

Examples:
*  [buildfarm-report_2024-08-30_09-27.json](https://github.com/user-attachments/files/16818629/buildfarm-report_2024-08-30_09-27.json)
* [report.md](https://github.com/user-attachments/files/16818631/report.md)

