### PR TITLE
Fix report flaky section

### DIFF
--- a/database/scripts/generate_report.rb
+++ b/database/scripts/generate_report.rb
@@ -25,14 +25,15 @@ options[:exclude] = Set.new() if options[:exclude].nil?
 options[:report_name] = "buildfarm-report_#{DateTime.now.strftime("%Y-%m-%d_%H-%M")}.json" if options[:report_name].nil?
 
 def generate_report(report_name, exclude_set)
-    report_regressions_all = BuildfarmToolsLib::test_regressions_all(filter_known: true)
+    report_regressions_all = BuildfarmToolsLib::test_regressions_all(filter_known: true).freeze # Freeze as this is a read-only variable
     report_regressions_consecutive = BuildfarmToolsLib::test_regressions_today(filter_known: true, only_consistent: true, group_issues: true, report_regressions: report_regressions_all)
+    report_flaky_regressions = BuildfarmToolsLib::flaky_test_regressions(filter_known: true, group_issues: true, report_regressions: report_regressions_all)
     
     report = {
         'urgent' => {
             'build_regressions' => BuildfarmToolsLib::build_regressions_today(filter_known: true),
-            'test_regressions_consecutive' => report_regressions_consecutive ,
-            'test_regressions_flaky' => BuildfarmToolsLib::flaky_test_regressions(filter_known: true, group_issues: true),
+            'test_regressions_consecutive' => report_regressions_consecutive,
+            'test_regressions_flaky' => report_flaky_regressions,
        },
        'maintenance' => {
             'jobs_last_success_date' => BuildfarmToolsLib::jobs_last_success_date(older_than_days: 7),

--- a/database/scripts/lib/buildfarm_tools.rb
+++ b/database/scripts/lib/buildfarm_tools.rb
@@ -51,7 +51,7 @@ module BuildfarmToolsLib
 
   def self.test_regressions_today(filter_known: false, only_consistent: false, group_issues: false, report_regressions: [])
     # Keys: job_name, build_number, error_name, build_datetime, node_name
-    out = report_regressions.clone(freeze: false) # Clone because we return the same array but modified
+    out = report_regressions.clone(freeze: false) # Clone because we return a modified version
     out = test_regressions_all(filter_known: filter_known) if out.empty?
     if only_consistent
       out.filter! { |tr| tr['age'].to_i >= CONSECUTIVE_THRESHOLD || tr['age'].to_i == WARNING_AGE_CONSTANT }


### PR DESCRIPTION
## Description

Daily report is failing because formatter doesn't find `e['reports']` in the flaky section. This is due to the fact that `test_regressions_all` wasn't returning the reports of the regressions.

### Changes
* Added a freeze to `report_regressions_all` variable, as it is intended to be read-only. The fact that it wasn't freezed before caused the problem of skipping flaky_tests section in the report.
* Added `include_reports` parameter to `test_regressions_all` method (explained in PR description)

Also, I want to test new daily workflow CI, so I will add the link to generated reports:
* [report.json](https://gist.github.com/Crola1702/c150b638b112a6344095a8d20fb45e49)
* [report.md](https://gist.github.com/Crola1702/7cf2050bdc06c68c359b89eb02fbe935)