### PR TITLE
Daily workflow ci update

### DIFF
--- a/.github/workflows/daily-workflow-ci.yml
+++ b/.github/workflows/daily-workflow-ci.yml
@@ -19,15 +19,13 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
-      - name: Extract branch name
-        run: echo "BRANCH=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
       - name: Generate today's report
         run: |
           cd database/scripts
           ./generate_report.rb -o ci_report.json
       - uses: actions/upload-artifact@v4
         with:
-          name: "$BRANCH-report"
+          name: "${{ github.ref_name }}-report"
           path: database/scripts/ci_report.json
           retention-days: 5 # Don't keep the artifact for much longer
           overwrite: true # Use the same artifact name each time to save space
@@ -39,6 +37,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: database/scripts/formatted_report.md
-          name: "$BRANCH-formatted-report"
+          name: "${{ github.ref_name }}-formatted-report"
           retention-days: 5
           overwrite: true

--- a/.github/workflows/daily-workflow-ci.yml
+++ b/.github/workflows/daily-workflow-ci.yml
@@ -1,4 +1,4 @@
-name: Daily Workflow CI
+name: Report Generation CI
 
 on:
   pull_request:

--- a/.github/workflows/daily-workflow-ci.yml
+++ b/.github/workflows/daily-workflow-ci.yml
@@ -1,4 +1,4 @@
-name: Report Generation CI
+name: Buildfarmer Log Daily Report Generation CI
 
 on:
   pull_request:


### PR DESCRIPTION
* Change action name to "Report Generation CI" (because it only test that the report is generated correctly, not other parts of daily workflow)
* Use github.ref_name instead of environment variable branch 
    * This was broken, and I downloaded a report called `$BRANCH-report.json`