### PR TITLE
Add ignored issues to database and reports

### DIFF
--- a/database/scripts/lib/buildfarm_tools.rb
+++ b/database/scripts/lib/buildfarm_tools.rb
@@ -41,6 +41,7 @@ module BuildfarmToolsLib
     if filter_known
       known_errors = known_issues(status: 'open')
       known_errors.concat known_issues(status: 'disabled')
+      known_errors.concat known_issues(status: 'ignored')
       known_error_names = Set.new(known_errors.map { |e| e['error_name'] })
       out.filter! { |e| !known_error_names.include? e['error_name'] }
     end

--- a/database/scripts/lib/buildfarm_tools.rb
+++ b/database/scripts/lib/buildfarm_tools.rb
@@ -41,7 +41,7 @@ module BuildfarmToolsLib
     if filter_known
       known_errors = known_issues(status: 'open')
       known_errors.concat known_issues(status: 'disabled')
-      known_errors.concat known_issues(status: 'ignored')
+      known_errors.concat known_issues(status: 'wontfix')
       known_error_names = Set.new(known_errors.map { |e| e['error_name'] })
       out.filter! { |e| !known_error_names.include? e['error_name'] }
     end

--- a/database/sql/create_table-test_fail_issues.sql
+++ b/database/sql/create_table-test_fail_issues.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS test_fail_issues(
             "OPEN",
             "CLOSED",
             "DISABLED",
-            "IGNORED"
+            "WONTFIX"
         )
     ) NOT NULL ON CONFLICT REPLACE DEFAULT "OPEN"
 );

--- a/database/sql/create_table-test_fail_issues.sql
+++ b/database/sql/create_table-test_fail_issues.sql
@@ -7,7 +7,8 @@ CREATE TABLE IF NOT EXISTS test_fail_issues(
         status IN (
             "OPEN",
             "CLOSED",
-            "DISABLED"
+            "DISABLED",
+            "IGNORED"
         )
     ) NOT NULL ON CONFLICT REPLACE DEFAULT "OPEN"
 );


### PR DESCRIPTION
# Description

This PR adds the `IGNORED` check to `test_fail_issues` table, to ignore an issue, i.e., not showing it anywhere in the reports to not cause noise.
