### PR TITLE
Show a warning if a job doesn't have a priority defined

### DIFF
--- a/database/scripts/lib/buildfarm_tools.rb
+++ b/database/scripts/lib/buildfarm_tools.rb
@@ -164,6 +164,10 @@ module BuildfarmToolsLib
         flaky_ratio = flaky_result.first['failure_percentage'].to_f/100.0
 
         job_priority = JOB_PRIORITIES[job]
+        if job_priority.nil?
+          puts "WARNING: No job priority for job #{job}. Defaulting to 1"
+          job_priority = 1
+        end
         job_priority = job_priority*1.5 if flaky_ratio == 1
         
         error_score_jobs[job] = [] if error_score_jobs[job].nil?


### PR DESCRIPTION
# Description

As the title says.

This is also a guard if the jobs priorities are haven't been updated after a new distribution release

Also, this is not a fix needed to make it work right now (altought it does), but instead an enhancement to make it resilient to failures.

> **Note:** Found it trying to debug why is the buildfarmer workflow failing. Spoiler: It's failing because we added \_upcoming_ distribution, but there are no job priorities defined for that collection.