### PR TITLE
Clean database

### DIFF
--- a/database/sql/create_table-build_failures.sql
+++ b/database/sql/create_table-build_failures.sql
@@ -1,7 +1,6 @@
 CREATE TABLE IF NOT EXISTS build_failures (
     job_name TEXT,
     build_number INTEGER,
-    log_output TEXT,
     failure_reason TEXT,
     last_section TEXT,
     PRIMARY KEY (job_name, build_number)


### PR DESCRIPTION
# Description

Buildfarmer database has exceeded 100MB file size limit from GitHub. 

This PR:
* Adds a backup file that contains all the data from the database before 2024-11-30
* Removes all data from buildfarmer.db previous to 2023-01-01
* Removes the `log_output` column from the `build_failures` table

## Changes

First, the data before 2023-01-01 was removed using the following sql script:

<details>
<summary>
clean-database-before-x.sql
</summary>

```sql
ALTER TABLE build_failures ADD id INTEGER;
UPDATE build_failures SET id = ROWID;

DELETE FROM build_failures
WHERE id IN (
	SELECT id FROM build_status
	WHERE build_status.build_datetime < '2023-01-01'
		AND build_failures.job_name = build_status.job_name
		AND build_failures.build_number = build_status.build_number
);

ALTER TABLE build_failures DROP COLUMN id;

DELETE FROM test_failures
WHERE id IN (
	SELECT id FROM build_status
	WHERE build_status.build_datetime < '2023-01-01'
		AND test_failures.job_name = build_status.job_name
		AND test_failures.build_number = build_status.build_number
);

DELETE FROM build_status
WHERE build_status.build_datetime < '2023-01-01';
```

</details>

However, this removed only 6MB from the database.

After that, I made an analysis of each table size, and found:

| Table | Size (approximately) |
| -- | -- |
| build_failures | 47 MB |
| build_status | 8,9 MB |
| test_failures | 35,8 MB |

build_failures table saves the last 100 lines of the log output. I wanted to see if this could be the column consuming a lot of space, so I ran:

```sql
UPDATE build_failures SET log_output = NULL;
ALTER TABLE build_failures DROP COLUMN log_output;
```

And the new size of the table is: 523.4 kB

I believe this column is not being used by anything. The idea behind it was to make pattern analysis over the last lines of the output, but the better option is to use `grep.rb` script from testdb scripts. That said, this will remove an unused column from the database, also helping us to free space.
