### PR TITLE
Add Kilted to ROS dashboard

### DIFF
--- a/ROS2.md
+++ b/ROS2.md
@@ -17,17 +17,17 @@ Builds [ros2.repos](https://raw.githubusercontent.com/ros2/ros2/master/ros2.repo
 
 From http://build.ros2.org . All Linux jobs, alternating days for released distributions: https://github.com/ros2/ros_buildfarm_config/pull/112
 
-|  | Humble | Jazzy | Rolling |
+|  | Humble | Jazzy | Kilted | Rolling |
 |---|---|---|---|
-| Nightly Release | [![Build Status][Hci-release-badge]][Hci-release] | [![Build Status][Jci-release-badge]][Jci-release] | [![Build Status][Rci-release-badge]][Rci-release] |
-| Nightly Debug | [![Build Status][Hci-debug-badge]][Hci-debug] | [![Build Status][Jci-debug-badge]][Jci-debug] | [![Build Status][Rci-debug-badge]][Rci-debug] |
-| Nightly Performance | [![Build Status][Hci-performance-badge]][Hci-performance] | [![Build Status][Jci-performance-badge]][Jci-performance] | [![Build Status][Rci-performance-badge]][Rci-performance] |
-| Nightly Connext | [![Build Status][Hci-connext-badge]][Hci-connext] | [![Build Status][Jci-connext-badge]][Jci-connext] | [![Build Status][Rci-connext-badge]][Rci-connext] |
-| Nightly Cyclone | [![Build Status][Hci-cyclone-badge]][Hci-cyclone] | [![Build Status][Jci-cyclone-badge]][Jci-cyclone] | [![Build Status][Rci-cyclone-badge]][Rci-cyclone] |
-| Nightly FastRTPS | [![Build Status][Hci-fastrtps-badge]][Hci-fastrtps] | [![Build Status][Jci-fastrtps-badge]][Jci-fastrtps] | [![Build Status][Rci-fastrtps-badge]][Rci-fastrtps] |
-| Nightly FastRTPS Dynamic | [![Build Status][Hci-fastrtps-dynamic-badge]][Hci-fastrtps-dynamic] | [![Build Status][Jci-fastrtps-dynamic-badge]][Jci-fastrtps-dynamic] | [![Build Status][Rci-fastrtps-dynamic-badge]][Rci-fastrtps-dynamic] |
-| Benchmarks | [![Build Status][Hci-benchmark-badge]][Hci-benchmark] | [![Build Status][Jci-benchmark-badge]][Jci-benchmark] | [![Build Status][Rci-benchmark-badge]][Rci-benchmark] |
-| Coverage | [![Build Status][Hci-coverage-badge]][Hci-coverage] | [![Build Status][Jci-coverage-badge]][Jci-coverage] | [![Build Status][Rci-coverage-badge]][Rci-coverage] |
+| Nightly Release | [![Build Status][Hci-release-badge]][Hci-release] | [![Build Status][Jci-release-badge]][Jci-release] | [![Build Status][Kci-release-badge]][Kci-release] | [![Build Status][Rci-release-badge]][Rci-release] |
+| Nightly Debug | [![Build Status][Hci-debug-badge]][Hci-debug] | [![Build Status][Jci-debug-badge]][Jci-debug] | [![Build Status][Kci-debug-badge]][Kci-debug] | [![Build Status][Rci-debug-badge]][Rci-debug] |
+| Nightly Performance | [![Build Status][Hci-performance-badge]][Hci-performance] | [![Build Status][Jci-performance-badge]][Jci-performance] | [![Build Status][Kci-performance-badge]][Kci-performance] | [![Build Status][Rci-performance-badge]][Rci-performance] |
+| Nightly Connext | [![Build Status][Hci-connext-badge]][Hci-connext] | [![Build Status][Jci-connext-badge]][Jci-connext] | [![Build Status][Kci-connext-badge]][Kci-connext] | [![Build Status][Rci-connext-badge]][Rci-connext] |
+| Nightly Cyclone | [![Build Status][Hci-cyclone-badge]][Hci-cyclone] | [![Build Status][Jci-cyclone-badge]][Jci-cyclone] | [![Build Status][Kci-cyclone-badge]][Kci-cyclone] | [![Build Status][Rci-cyclone-badge]][Rci-cyclone] |
+| Nightly FastRTPS | [![Build Status][Hci-fastrtps-badge]][Hci-fastrtps] | [![Build Status][Jci-fastrtps-badge]][Jci-fastrtps] | [![Build Status][Kci-fastrtps-badge]][Kci-fastrtps] | [![Build Status][Rci-fastrtps-badge]][Rci-fastrtps] |
+| Nightly FastRTPS Dynamic | [![Build Status][Hci-fastrtps-dynamic-badge]][Hci-fastrtps-dynamic] | [![Build Status][Jci-fastrtps-dynamic-badge]][Jci-fastrtps-dynamic] | [![Build Status][Kci-fastrtps-dynamic-badge]][Kci-fastrtps-dynamic] | [![Build Status][Rci-fastrtps-dynamic-badge]][Rci-fastrtps-dynamic] |
+| Benchmarks | [![Build Status][Hci-benchmark-badge]][Hci-benchmark] | [![Build Status][Jci-benchmark-badge]][Jci-benchmark] | [![Build Status][Kci-benchmark-badge]][Kci-benchmark] | [![Build Status][Rci-benchmark-badge]][Rci-benchmark] |
+| Coverage | [![Build Status][Hci-coverage-badge]][Hci-coverage] | [![Build Status][Jci-coverage-badge]][Jci-coverage] | [![Build Status][Kci-coverage-badge]][Kci-coverage] | [![Build Status][Rci-coverage-badge]][Rci-coverage] |
 
 ## Upload OSUOSL Repositories
 ### ROS 1
@@ -50,6 +50,7 @@ From http://build.ros2.org . All Linux jobs, alternating days for released distr
 | Noetic | [![Build Status](https://build.ros.org/job/Nrel_sync-packages-to-testing_focal_amd64/badge/icon)](https://build.ros.org/job/Nrel_sync-packages-to-testing_focal_amd64/) |
 | Humble | [![Build Status](https://build.ros2.org/job/Hrel_sync-packages-to-testing_jammy_amd64/badge/icon)](https://build.ros2.org/job/Hrel_sync-packages-to-testing_jammy_amd64/) |
 | Jazzy | [![Build Status](https://build.ros2.org/job/Jrel_sync-packages-to-testing_noble_amd64/badge/icon)](https://build.ros2.org/job/Jrel_sync-packages-to-testing_noble_amd64/) |
+| Kilted | [![Build Status](https://build.ros2.org/job/Krel_sync-packages-to-testing_noble_amd64/badge/icon)](https://build.ros2.org/job/Krel_sync-packages-to-testing_noble_amd64/) |
 | Rolling | [![Build Status](https://build.ros2.org/job/Rrel_sync-packages-to-testing_noble_amd64/badge/icon)](https://build.ros2.org/job/Rrel_sync-packages-to-testing_noble_amd64/) |
 
 [nightly-linux-debug]: https://ci.ros2.org/view/nightly/job/nightly_linux_debug
@@ -125,6 +126,25 @@ From http://build.ros2.org . All Linux jobs, alternating days for released distr
 [Jci-benchmark]: http://build.ros2.org/view/Jci/job/Jci__benchmark_ubuntu_noble_amd64/
 [Jci-coverage-badge]: https://ci.ros2.org/buildStatus/icon?job=nightly_linux_jazzy_coverage
 [Jci-coverage]: https://ci.ros2.org/job/nightly_linux_jazzy_coverage/
+
+[Kci-release-badge]: http://build.ros2.org/buildStatus/icon?job=Kci__nightly-release_ubuntu_noble_amd64
+[Kci-release]: http://build.ros2.org/view/Kci/job/Kci__nightly-release_ubuntu_noble_amd64/
+[Kci-debug-badge]: http://build.ros2.org/buildStatus/icon?job=Kci__nightly-debug_ubuntu_noble_amd64
+[Kci-debug]: http://build.ros2.org/view/Kci/job/Kci__nightly-debug_ubuntu_noble_amd64/
+[Kci-performance-badge]: http://build.ros2.org/buildStatus/icon?job=Kci__nightly-performance_ubuntu_noble_amd64
+[Kci-performance]: http://build.ros2.org/view/Kci/job/Kci__nightly-performance_ubuntu_noble_amd64/
+[Kci-connext-badge]: http://build.ros2.org/buildStatus/icon?job=Kci__nightly-connext_ubuntu_noble_amd64
+[Kci-connext]: http://build.ros2.org/view/Kci/job/Kci__nightly-connext_ubuntu_noble_amd64/
+[Kci-cyclone-badge]: http://build.ros2.org/buildStatus/icon?job=Kci__nightly-cyclonedds_ubuntu_noble_amd64
+[Kci-cyclone]: http://build.ros2.org/view/Kci/job/Kci__nightly-cyclonedds_ubuntu_noble_amd64/
+[Kci-fastrtps-badge]: http://build.ros2.org/buildStatus/icon?job=Kci__nightly-fastrtps_ubuntu_noble_amd64
+[Kci-fastrtps]: http://build.ros2.org/view/Kci/job/Kci__nightly-fastrtps_ubuntu_noble_amd64/
+[Kci-fastrtps-dynamic-badge]: http://build.ros2.org/buildStatus/icon?job=Kci__nightly-fastrtps-dynamic_ubuntu_noble_amd64
+[Kci-fastrtps-dynamic]:  http://build.ros2.org/view/Kci/job/Kci__nightly-fastrtps-dynamic_ubuntu_noble_amd64/
+[Kci-benchmark-badge]: http://build.ros2.org/buildStatus/icon?job=Kci__benchmark_ubuntu_noble_amd64
+[Kci-benchmark]: http://build.ros2.org/view/Kci/job/Kci__benchmark_ubuntu_noble_amd64/
+[Kci-coverage-badge]: https://ci.ros2.org/buildStatus/icon?job=nightly_linux_kilted_coverage
+[Kci-coverage]: https://ci.ros2.org/job/nightly_linux_kilted_coverage/
 
 [Rci-release-badge]: http://build.ros2.org/buildStatus/icon?job=Rci__nightly-release_ubuntu_noble_amd64
 [Rci-release]: http://build.ros2.org/view/Rci/job/Rci__nightly-release_ubuntu_noble_amd64/

--- a/ROS2.md
+++ b/ROS2.md
@@ -18,7 +18,7 @@ Builds [ros2.repos](https://raw.githubusercontent.com/ros2/ros2/master/ros2.repo
 From http://build.ros2.org . All Linux jobs, alternating days for released distributions: https://github.com/ros2/ros_buildfarm_config/pull/112
 
 |  | Humble | Jazzy | Kilted | Rolling |
-|---|---|---|---|
+|---|---|---|---|---|
 | Nightly Release | [![Build Status][Hci-release-badge]][Hci-release] | [![Build Status][Jci-release-badge]][Jci-release] | [![Build Status][Kci-release-badge]][Kci-release] | [![Build Status][Rci-release-badge]][Rci-release] |
 | Nightly Debug | [![Build Status][Hci-debug-badge]][Hci-debug] | [![Build Status][Jci-debug-badge]][Jci-debug] | [![Build Status][Kci-debug-badge]][Kci-debug] | [![Build Status][Rci-debug-badge]][Rci-debug] |
 | Nightly Performance | [![Build Status][Hci-performance-badge]][Hci-performance] | [![Build Status][Jci-performance-badge]][Jci-performance] | [![Build Status][Kci-performance-badge]][Kci-performance] | [![Build Status][Rci-performance-badge]][Rci-performance] |


### PR DESCRIPTION
As the title says, straightforward PR, I think those jobs haven't all run yet, we can merge after the first set of those gets added.