### PR TITLE
Add multiple issues script

### DIFF
--- a/database/scripts/add_multiple_known_errors.rb
+++ b/database/scripts/add_multiple_known_errors.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative 'lib/buildfarm_tools'
+
+if ['-h', '--help', 'help'].include? ARGV.first
+  puts "Usage: '#{$0} <github_issue_url>'\n" \
+    'Write all the errors names in each line, ending with an empty newline'
+  exit(0)
+end
+
+github_issue = ARGV.first
+
+unless github_issue.include? 'https://github.com/'
+  puts "Specify github issue using '#{$0} <github_issue_url>'"
+  exit(1)
+end
+
+errors = []
+puts 'Enter all error names:'
+while true
+  err = $stdin.gets.chomp
+  break if err.empty?
+
+  errors << err
+end
+
+count = 0
+errors.each do |error_name|
+  BuildfarmToolsLib.test_regression_flakiness(error_name).each do |line|
+    exit_status = BuildfarmToolsLib.add_known_issue(error_name, line['job_name'], github_issue)
+    raise BuildfarmToolsLib::BuildfarmToolsError unless exit_status.zero?
+
+    count += 1
+  end
+end
+puts "Added #{count} lines to known issues"

--- a/database/scripts/lib/buildfarm_tools.rb
+++ b/database/scripts/lib/buildfarm_tools.rb
@@ -179,6 +179,14 @@ module BuildfarmToolsLib
     error_score_jobs.each_value.map {|e| e.max}.sum.round(3)
   end
 
+  def self.add_known_issue(error_name, job_name, github_issue)
+    Open3.popen3("./issue_save_new.sh '#{error_name}' '#{error_name.split('.').first}' '#{job_name}' '#{github_issue}'") do |_, _, _, t|
+      t.value.exitstatus
+    end
+  rescue StandardError => e
+    raise BuildfarmToolsError, e
+  end
+
   def self.run_command(cmd, args: [], keys: [])
     cmd += " '#{args.shift}'" until args.empty?
     begin


### PR DESCRIPTION
This PR:
- Adds `add_known_issue` function to BuildfarmToolsLib module to call `issue_save_new.sh`, which adds known issues to buildfarmer database
- Adds `add_multiple_known_errors.rb`, which takes all the specified test regressions names, looks for all the jobs where they're happening, and adds them to the buildfarmer database using the previous function.

Usage: `./add_multiple_known_errors.rb <github_issue_url>`, then write all the errors names in each line, ending with an empty newline

<details><summary>Example:</summary>

```
$ ./add_multiple_known_errors.rb https://github.com/ros2/rmw_cyclonedds/issues/53
Enter all error names:
projectroot.gtest_executor__rmw_cyclonedds_cpp
projectroot.test_play_timing__rmw_cyclonedds_cpp
projectroot.test_keyboard_controls__rmw_cyclonedds_cpp
projectroot.test_record_regex__rmw_cyclonedds_cpp
projectroot.test_play_callbacks__rmw_cyclonedds_cpp
projectroot.test_play_seek__rmw_cyclonedds_cpp
projectroot.test_secure_publisher_subscriber__UnboundedSequences__rmw_cyclonedds_cpp__secure_no
t_connecting_1
projectroot.test_secure_publisher_subscriber__UnboundedSequences__rmw_cyclonedds_cpp__secure_no
t_connecting_0
projectroot.test_play_services__rmw_cyclonedds_cpp
test_rclcpp.gtest_executor__rmw_cyclonedds_cpp.gtest.missing_result
sros2.test.sros2.commands.security.verbs.test_generate_policy_no_nodes.test_generate_policy_no_
nodes

Added 89 lines to known issues
```

</details>