### PR TITLE
Fix workflow when generate report has warnings

### DIFF
--- a/.github/workflows/dailyWorkflow.yml
+++ b/.github/workflows/dailyWorkflow.yml
@@ -50,7 +50,7 @@ jobs:
         - name: Generate today's report
           run: |
             cd database/scripts
-            echo "REPORT_NAME=$(./generate_report.rb)" >> $GITHUB_ENV
+            echo "REPORT_NAME=$(./generate_report.rb | tail -1)" >> $GITHUB_ENV
         - uses: actions/upload-artifact@v4
           with:
             name: ${{ env.REPORT_NAME }}


### PR DESCRIPTION
When `./generate_report.rb` runs, it can show warnings regarding jobs that don't have priorities.

In that case, `"REPORT_NAME=$(./generate_report.rb)" >> $GITHUB_ENV` fails because GITHUB_ENV expects a single line, but the warnings add multiple lines, so the workflow fails with: `Daily Workflow Unable to process file command 'env' successfully.`