### PR TITLE
Don't fail if a job doesn't have priority

### DIFF
--- a/.github/workflows/daily-workflow-ci.yml
+++ b/.github/workflows/daily-workflow-ci.yml
@@ -33,7 +33,7 @@ jobs:
           cd database/scripts
           ./generate_report.rb -o ci_report.json | tee report_log.txt
           echo "REPORT WARNINGS:"
-          head report_log.txt -n -1 | awk -F: '{ print "::warning title=No priority for job::"$2 }'
+          head report_log.txt -n -1 | awk -F: '{ print "::warning title={No priority for job}::"$2 }'
       - uses: actions/upload-artifact@v4
         with:
           name: "${{ env.REPORT_NAME }}-report"

--- a/.github/workflows/dailyWorkflow.yml
+++ b/.github/workflows/dailyWorkflow.yml
@@ -52,7 +52,7 @@ jobs:
             cd database/scripts
             echo "REPORT_NAME=$(./generate_report.rb | tee report_log.txt | tail -1)" >> $GITHUB_ENV
             echo "REPORT WARNINGS:"
-            head report_log.txt -n -1 | awk -F: '{ print "::warning title=No priority for job::"$2 }'
+            head report_log.txt -n -1 | awk -F: '{ print "::warning title={No priority for job}::"$2 }'
         - uses: actions/upload-artifact@v4
           with:
             name: ${{ env.REPORT_NAME }}


### PR DESCRIPTION
The [current failure](https://github.com/osrf/buildfarm-tools/actions/runs/17944869645/job/51028798410) happens because the generate_report scripts show an unknown priority of a job, and outputs a warning message, and the result of generate_report script is parsed into the github environment.

This can be fixed easily by adding `| tail -1` to the generate_report script output. But this isn't optimal, as the warnings provide important information for buildfarm tools

Instead, now the log is saved using `| tee report_log.txt` and then parsed using awk to output warning messages: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-warning-message