### PR TITLE
Add recent timeouts script

### DIFF
--- a/database/scripts/recent_timeouts.sql
+++ b/database/scripts/recent_timeouts.sql
@@ -5,7 +5,7 @@ SELECT build_status.job_name,
 	build_status.status
 FROM build_status
 	JOIN server_status ON build_status.job_name == server_status.job_name
-WHERE server_status.domain == 'https://ci.ros2.org' 
+WHERE server_status.domain == '@param1@'
 	AND build_status.buildtime > 32400000 -- 9 hours
 	AND build_status.build_datetime > DATE('now',  '-60 days')
 ORDER BY build_status.build_datetime DESC;


### PR DESCRIPTION
Add Sql script to check the timeouts (actually, builds that run for more than 9 hours) in the last 60 days.

<details><summary>Running it as: <code>./sql_run.sh recent_timeouts.sql 'https://ci.ros2.org'</code>:</summary>

job_name|build_number|build_datetime|buildtime|status
-- | -- | -- | -- | --
nightly_win_rel|3672|2026-01-12 04:00:01.062000|36062343|ABORTED
nightly_linux-rhel_debug|2567|2026-01-11 07:24:07.592000|36020574|ABORTED
nightly_win_rel|3669|2026-01-09 04:00:01.043000|36064958|ABORTED
nightly_linux-aarch64_debug|3441|2026-01-09 04:00:00.994000|36020902|ABORTED
nightly_win_rep|3970|2026-01-03 04:00:01.081000|36045093|ABORTED
nightly_win_rep|3969|2026-01-02 04:00:01.066000|36041604|ABORTED
nightly_win_rep|3966|2025-12-30 04:00:01.058000|36033638|ABORTED
nightly_linux-rhel_debug|2546|2025-12-28 04:00:01.004000|36019893|ABORTED
nightly_win_rel|3656|2025-12-27 04:00:01.057000|36061115|ABORTED
nightly_linux-rhel_release|2521|2025-12-26 04:00:01.018000|36021286|ABORTED
nightly_linux-rhel_debug|2543|2025-12-25 04:00:00.984000|36020600|ABORTED
nightly_win_rel|3653|2025-12-24 04:00:01.068000|36057727|ABORTED
nightly_linux-rhel_debug|2542|2025-12-24 04:00:00.984000|36022778|ABORTED
nightly_win_rel|3652|2025-12-23 04:00:01.067000|38713062|ABORTED
nightly_linux-aarch64_debug|3424|2025-12-23 04:00:00.985000|38684348|ABORTED
nightly_linux-aarch64_debug|3419|2025-12-20 06:57:24.700000|148010584|FAILURE
nightly_linux-rhel_debug|2538|2025-12-20 04:54:58.439000|205856797|ABORTED
nightly_win_rep|3956|2025-12-20 04:00:01.008000|69813774|UNSTABLE
nightly_linux-rhel_repeated|2514|2025-12-19 22:28:34.556000|229031251|ABORTED
nightly_linux-rhel_repeated|2513|2025-12-19 10:28:58.404000|43176143|FAILURE
nightly_linux-aarch64_repeated|3400|2025-12-19 04:04:02.517000|36648991|ABORTED
nightly_win_rep|3955|2025-12-19 04:00:01.044000|36935493|ABORTED
nightly_linux-rhel_release|2514|2025-12-19 04:00:01.004000|36885999|ABORTED
nightly_win_rep|3954|2025-12-18 04:00:01.051000|61902244|UNSTABLE
nightly_linux-aarch64_debug|3416|2025-12-18 04:00:00.985000|36638097|ABORTED
nightly_win_rel|3646|2025-12-17 04:00:01.042000|71285302|UNSTABLE
nightly_linux-aarch64_release|3390|2025-12-16 04:00:01.185000|47656931|FAILURE
nightly_win_rel|3642|2025-12-13 04:00:01.074000|203715903|ABORTED
nightly_linux-aarch64_release|3386|2025-12-13 04:00:00.995000|76032400|FAILURE
nightly_linux-rhel_release|2505|2025-12-11 04:00:01.028000|47038250|FAILURE
nightly_linux-rhel_release|2500|2025-12-07 04:00:01.043000|119068905|FAILURE


</details>