### PR TITLE
Fix to nil in report formatted report

### DIFF
--- a/database/scripts/lib/report_formatter.rb
+++ b/database/scripts/lib/report_formatter.rb
@@ -168,8 +168,11 @@ module ReportFormatter
       errors_str = "<details><summary>#{errors.size} errors</summary>#{errors_str}</details>" if errors.size > 9
       
       # Add issue report data to it's respective project table
-      project = iss_report.first['project']
-      tables[project][iss_report.first['status'].downcase] += "| `#{iss_report.first['github_issue']}` | #{iss_report.first['priority']} | #{jobs_str} | #{errors_str} |\n"
+      project = iss_report.first['project']&.upcase
+      status = iss_report.first['status']&.downcase
+      next unless project && status && tables.key?(project) && tables[project].key?(status)
+
+      tables[project][status] += "| `#{iss_report.first['github_issue']}` | #{iss_report.first['priority']} | #{jobs_str} | #{errors_str} |\n"
     end
 
     out = ""


### PR DESCRIPTION
Today report failed with this log

```
/home/runner/work/buildfarm-tools/buildfarm-tools/database/scripts/lib/report_formatter.rb:172:in `block in test_regressions_known': undefined method `[]' for nil:NilClass (NoMethodError)

      tables[project][iss_report.first['status'].downcase] += "| `#{iss_report.first['github_issue']}` | #{iss_report.first['priority']} | #{jobs_str} | #{errors_str} |\n"
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	from /home/runner/work/buildfarm-tools/buildfarm-tools/database/scripts/lib/report_formatter.rb:161:in `each'
	from /home/runner/work/buildfarm-tools/buildfarm-tools/database/scripts/lib/report_formatter.rb:161:in `test_regressions_known'
	from ./format_report.rb:15:in `<main>'
Error: Process completed with exit code 1.
```
As I understood it is because the script got a project in downcase