### PR TITLE
Added job name 

### DIFF
--- a/database/scripts/get_known_issues.sql
+++ b/database/scripts/get_known_issues.sql
@@ -1,4 +1,5 @@
 SELECT
+    test_fail_issues.error_name,
     test_fail_issues.job_name,
     test_fail_issues.github_issue,
     test_fail_issues.status,


### PR DESCRIPTION
To fix `generate_report.rb` after merging the changes in `get_known_issues.sql` we needed to add again the missing columns that are required by `format_report.rb`

```diff
+ test_fail_issues.error_name,
+ test_fail_issues.job_name,
```