### PR TITLE
Updated opened_issues script to help spreadsheet script

### DIFF
--- a/database/scripts/get_active_known_issues.sql
+++ b/database/scripts/get_active_known_issues.sql
@@ -1,0 +1,10 @@
+SELECT 
+    github_issue,
+    status,
+    assignee,
+    priority,
+    created_at,
+    issue_last_activity
+FROM test_fail_issues
+WHERE status != "CLOSED"
+GROUP BY github_issue;

--- a/database/scripts/get_opened_known_issues.sql
+++ b/database/scripts/get_opened_known_issues.sql
@@ -1,10 +1,5 @@
-SELECT 
-    github_issue,
-    status,
-    assignee,
-    priority,
-    created_at,
-    issue_last_activity
+SELECT error_name,
+    github_issue
 FROM test_fail_issues
-WHERE status != "CLOSED"
+WHERE status = "OPEN"
 GROUP BY github_issue;


### PR DESCRIPTION
Issues spreadsheet [#67](https://github.com/osrf/buildfarm-tools/issues/202) needs to fetch not closed issues, to do that this script will fetch what we need

```diff
- SELECT error_name,
+ SELECT 
      github_issue,
+      status,
+      assignee,
+      priority,
+      created_at,
+      issue_last_activity
  FROM test_fail_issues
- WHERE status = "OPEN"
+ WHERE status != "CLOSED"
  GROUP BY github_issue;
```