### PR TITLE
Use `job_name` parameter when filtering known issues

### DIFF
--- a/database/scripts/lib/buildfarm_tools.rb
+++ b/database/scripts/lib/buildfarm_tools.rb
@@ -48,7 +48,7 @@ module BuildfarmToolsLib
     if include_reports
       out.each do |e|
         reports = test_regression_reported_issues e['error_name'], job_name: e['job_name']
-        e['reports'] = reports unless reports.empty?
+        e['reports'] = reports
       end
     end
     out
@@ -64,7 +64,7 @@ module BuildfarmToolsLib
     end
     out.each do |e|
       reports = test_regression_reported_issues e['error_name'], job_name: e['job_name']
-      e['reports'] = reports unless reports.empty?
+      e['reports'] = reports
     end
     if group_issues
       # Group by (job_name, age)


### PR DESCRIPTION
Fixes #222 

As the title says. Extra details on https://github.com/osrf/buildfarm-tools/issues/222#issuecomment-3916338321

This applies for `test_regressions_all` and `test_regressions_today` methods.

I'll upload the formatted report here when CI runs