### PR TITLE
Updated urllib3 dependency to avoid dependabot vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 python-jenkins
 pyyaml
-# Pining version due to error introduced in >2.0.0  https://bugs.launchpad.net/python-jenkins/+bug/2018567
-urllib3<2.0.0
+urllib3>=2.5.0


### PR DESCRIPTION
GitHub Dependabot flagged a moderate security vulnerability in the default branch. https://github.com/osrf/buildfarm-tools/security/dependabot/1

- **Package:** `urllib3`
- **Affected versions:** `< 2.5.0`
- **Patched version:** `2.5.0`
- **Details:** `PoolManager` ignores the `retries` parameter, failing to disable redirects and potentially exposing the application to SSRF or open redirect vulnerabilities.

As a comment in `requirements.txt` said, this library was pinned in that version because some time ago it had a bug in `Default timeout` but this was fixed in `2024-09-30`

**Remediation:**
Update `requirements.txt` to enforce `urllib3>=2.5.0`.

### Historical question
Is this really being used in any part? I can´t find any call to this dependency