### PR TITLE
Changed flaky tests history generate method

### DIFF
--- a/reports/dashboard/index.html
+++ b/reports/dashboard/index.html
@@ -1888,7 +1888,10 @@
             byTestName.set(item.test_name, item);
           }
         });
-        const available = [...byTestName.values()].filter((item) => (historyMap[item.test_name] || []).length);
+        const available = [...byTestName.values()].filter((item) => {
+          const historyKey = buildHistoryKey(item.test_name, null);
+          return (historyMap[historyKey] || []).length;
+        });
         if (!available.length) {
           return '<span class="muted">No history</span>';
         }


### PR DESCRIPTION
Previously, the dashboard wasn't showing the 90 days history trend for flaky tests, this was because we were using `historyMap[item.test_name]` as in the first version, but it was updated to `buildHistoryKey(item.test_name, null)` to produce the test structure we are currently using